### PR TITLE
Implement Deadline funcs by using net.Pipe

### DIFF
--- a/inproc_test.go
+++ b/inproc_test.go
@@ -74,3 +74,107 @@ func TestINPROC(t *testing.T) {
 	l.Close()
 	wg.Wait()
 }
+
+func TestDeadline(t *testing.T) {
+	address := ":9999"
+	l, err := Listen(address)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	defer l.Close()
+	go func() {
+		for i := 0; i < 2; i++ {
+			conn, err := l.Accept()
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			if _, err := conn.Read(make([]byte, 1)); err != nil {
+				t.Error(err)
+				return
+			}
+			if _, err := conn.Write([]byte{0}); err != nil {
+				t.Error(err)
+				return
+			}
+			conn.Close()
+		}
+	}()
+	conn, err := Dial(address)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	// Test SetReadDeadline
+	conn.SetReadDeadline(time.Now().Add(1))
+	n, _ := conn.Read(make([]byte, 1))
+	if n != 0 {
+		t.Errorf("read deadline error %d != %d", n, 0)
+		return
+	}
+	// Write value to progress listener status
+	if _, err := conn.Write([]byte{0}); err != nil {
+		t.Error(err)
+		return
+	}
+	// Reset read deadline
+	conn.SetReadDeadline(time.Time{})
+
+	// Test SetWriteDeadline
+	conn.SetWriteDeadline(time.Now().Add(1))
+	if _, err := conn.Write([]byte{0}); err == nil {
+		t.Error(err)
+		return
+	}
+	n, _ = conn.Write([]byte{0})
+	if n != 0 {
+		t.Errorf("write deadline error %d != %d", n, 0)
+		return
+	}
+	// Read value to progress listener status, then close connection
+	if _, err := conn.Read(make([]byte, 1)); err != nil {
+		t.Error(err)
+		return
+	}
+	// Reset write deadline
+	conn.SetWriteDeadline(time.Time{})
+	conn.Close()
+
+	// Test SetDeadline
+	conn, err = Dial(address)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	conn.SetDeadline(time.Now().Add(1))
+	// Test read
+	n, _ = conn.Read(make([]byte, 1))
+	if n != 0 {
+		t.Errorf("deadline error %d != %d", n, 0)
+		return
+	}
+	// Reset deadline
+	conn.SetDeadline(time.Time{})
+
+	// Write value to progress listener status
+	if _, err := conn.Write([]byte{0}); err != nil {
+		t.Error(err)
+		return
+	}
+	conn.SetDeadline(time.Now().Add(1))
+	// Test write
+	n, _ = conn.Write([]byte{0})
+	if n != 0 {
+		t.Errorf("deadline error %d != %d", n, 0)
+		return
+	}
+	// Read value to progress listener status, then close connection
+	_, err = conn.Read(make([]byte, 1))
+	if err == nil {
+		t.Error(err)
+		return
+	}
+	conn.Close()
+}


### PR DESCRIPTION
Using `net.Pipe` instead of `io.Pipe` we get Deadline functions out of the box.